### PR TITLE
Build project with java 1.8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ plugins {
 group = "ai.datahunters.md"
 version = "0.0.1-SNAPSHOT"
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 repositories {

--- a/src/main/java/ai/datahunters/md/server/photos/http/ToApiConversions.java
+++ b/src/main/java/ai/datahunters/md/server/photos/http/ToApiConversions.java
@@ -13,8 +13,8 @@ public class ToApiConversions {
     }
     public static SearchResponse responseFromPhotos(Page<PhotoEntity> modelPhotos) {
         List<Photo> apiPhotos = modelPhotos.stream().map(ToApiConversions::toApiPhoto).collect(Collectors.toList());
-        var page = modelPhotos.getNumber();
-        var total = modelPhotos.getTotalElements();
+        int page = modelPhotos.getNumber();
+        long total = modelPhotos.getTotalElements();
         return SearchResponse.builder()
                 .photos(apiPhotos)
                 .page(page)

--- a/src/main/java/ai/datahunters/md/server/photos/http/json/read/SearchRequestRead.java
+++ b/src/main/java/ai/datahunters/md/server/photos/http/json/read/SearchRequestRead.java
@@ -23,7 +23,7 @@ public class SearchRequestRead {
     }
 
     private static ObjectMapper buildObjectMapper() {
-        var mapper = new ObjectMapper();
+        ObjectMapper mapper = new ObjectMapper();
         mapper.registerModule(new Jdk8Module());
         return mapper;
     }

--- a/src/main/java/ai/datahunters/md/server/photos/upload/UploadService.java
+++ b/src/main/java/ai/datahunters/md/server/photos/upload/UploadService.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 import java.nio.channels.AsynchronousFileChannel;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -28,10 +29,16 @@ public class UploadService {
             return DataBufferUtils.write(filePart.content(), channel, 0)
                     .doOnComplete(() -> System.out.println("uploaded"))
                     .collect(Collectors.counting())
-                    .map(count -> List.of(tempFile.toAbsolutePath().toString()))
+                    .map(count -> buildResultList(tempFile.toAbsolutePath().toString()))
                     .map(ToApiConversions::responseFromUploadedFiles);
         } catch (IOException e) {
             return Mono.error(e);
         }
+    }
+
+    private List<String> buildResultList(String file) {
+        List<String> l = new ArrayList<>();
+        l.add(file);
+        return l;
     }
 }

--- a/src/test/java/ai/datahunters/md/server/server/SearchPhotosEndpointTest.java
+++ b/src/test/java/ai/datahunters/md/server/server/SearchPhotosEndpointTest.java
@@ -8,6 +8,7 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -17,6 +18,7 @@ import org.springframework.web.reactive.function.BodyInserters;
 
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.List;
@@ -39,10 +41,10 @@ public class SearchPhotosEndpointTest {
 
     @Test
     public void searchByType() throws IOException {
-        var expectedRequest = SearchRequest.builder()
+        SearchRequest expectedRequest = SearchRequest.builder()
                 .text_query(Optional.of("test"))
                 .build();
-        var photo = PhotoEntity.builder()
+        PhotoEntity photo = PhotoEntity.builder()
                 .id("1234")
                 .basePath("base_path")
                 .filePath("file_path")
@@ -51,14 +53,14 @@ public class SearchPhotosEndpointTest {
                 .metaData(prepareDynamicFields())
                 .build();
 
-        var page = new PageImpl<>(List.of(photo));
+        Page<PhotoEntity> page = new PageImpl<>(List.of(photo));
         given(repo.search(expectedRequest)).willReturn(CompletableFuture.completedFuture(page));
 
-        var expectedResponseFile = Paths.get(
+        Path expectedResponseFile = Paths.get(
                 getClass().getClassLoader().getResource("photosendpointtest/expected_response.json").getPath()
         );
 
-        var expectedResponse = Files.readString(expectedResponseFile);
+        String expectedResponse = Files.readString(expectedResponseFile);
         webTestClient
                 // Create a GET request to test an endpoint
                 .post()
@@ -76,7 +78,7 @@ public class SearchPhotosEndpointTest {
     }
 
     Map<String, List<String>> prepareDynamicFields() {
-        var map = new HashMap<String, List<String>>();
+        Map<String, List<String>> map = new HashMap<>();
         map.put("dynamic_field_1", List.of("el11", "el12"));
         map.put("dynamic_field_2", List.of("el21", "el22"));
         return map;


### PR DESCRIPTION
Most of spark packages are running java 8, to decrease the amount of
work for people setting up our app, we decided to go with the standard.
Fortunately the only things we needed to change were just vars.